### PR TITLE
Use more correct variable names

### DIFF
--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -52,19 +52,19 @@ class WebtoolsGeocoding extends AbstractHttpProvider implements Provider
         }
 
         $url = sprintf(self::ENDPOINT_URL, urlencode($address), $query->getLimit(), $query->getLocale());
-        $content = $this->getUrlContents($url);
-        $json = \json_decode($content);
+        $json = $this->getUrlContents($url);
+        $content = \json_decode($json);
 
-        if (empty($json)) {
+        if (empty($content)) {
             throw InvalidServerResponse::create($url);
         }
 
-        if (empty($json->geocodingRequestsCollection)) {
+        if (empty($content->geocodingRequestsCollection)) {
             return new AddressCollection([]);
         }
 
         $results = [];
-        foreach ($json->geocodingRequestsCollection as $collection) {
+        foreach ($content->geocodingRequestsCollection as $collection) {
             if (empty($collection->result->features)) {
                 continue;
             }


### PR DESCRIPTION
The names of the `$content` and `$json` variables are poorly chosen:

```
        $content = $this->getUrlContents($url); // $content contains JSON data.
        $json = \json_decode($content); // $json contains data but it is no longer in JSON format.
```