### PR TITLE
OPENEUROPA-2258: Use PHP 7.2 in drone and docker image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,14 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     environment:
       - DOCUMENT_ROOT=/test/webtools-geocoding-provider
 
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     volumes:
       - /cache:/cache
     commands:
@@ -21,12 +21,17 @@ pipeline:
 # large number of false positives. Re-enable this once the tool works properly.
 #  grumphp:
 #    group: test
-#    image: fpfis/httpd-php-ci:7.1
+#    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
 #    commands:
 #      - ./vendor/bin/grumphp run
 
   phpunit:
     group: test
-    image: fpfis/httpd-php-ci:7.1
+    image: fpfis/httpd-php-ci:${PHP_VERSION=7.2}
     commands:
       - ./vendor/bin/phpunit
+
+matrix:
+  PHP_VERSION:
+    - 7.1
+    - 7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone.