### PR TITLE
Allow to optionally pass a referer header

### DIFF
--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -156,7 +156,7 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
    * {@inheritdoc}
    */
   protected function getRequest(string $url): RequestInterface {
-    $request = $this->getMessageFactory()->createRequest('GET', $url);
+    $request = parent::getRequest($url);
     if (!empty($this->referer)) {
       $request = $request->withHeader('Referer', $this->referer);
     }

--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -36,7 +36,7 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
   /**
    * Constructs a WebtoolsGeocoding provider.
    */
-  public function __construct(HttpClient $client, string $referer = '') {
+  public function __construct(HttpClient $client, string $referer = NULL) {
     parent::__construct($client);
     $this->referer = $referer;
   }

--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -36,7 +36,7 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
   /**
    * Constructs a WebtoolsGeocoding provider.
    */
-  public function __construct(HttpClient $client, string $referer = NULL) {
+  public function __construct(HttpClient $client, ?string $referer = NULL) {
     parent::__construct($client);
     $this->referer = $referer;
   }

--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -13,6 +13,8 @@ use Geocoder\Model\Address;
 use Geocoder\Model\AddressCollection;
 use Geocoder\Query\GeocodeQuery;
 use Geocoder\Query\ReverseQuery;
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Webtools Geocoding provider for Geocoder PHP.
@@ -23,6 +25,21 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
    * @var string
    */
   const ENDPOINT_URL = 'https://europa.eu/webtools/rest/geocoding/?f=json&text=%s&maxLocations=%d&outFields=*';
+
+  /**
+   * Optional referer.
+   *
+   * @var string
+   */
+  private $referer;
+
+  /**
+   * Constructs a WebtoolsGeocoding provider.
+   */
+  public function __construct(HttpClient $client, string $referer = '') {
+    parent::__construct($client);
+    $this->referer = $referer;
+  }
 
   /**
    * {@inheritdoc}
@@ -134,4 +151,17 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
 
     return $address_data;
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getRequest(string $url): RequestInterface {
+    $request = $this->getMessageFactory()->createRequest('GET', $url);
+    if (!empty($this->referer)) {
+      $request = $request->withHeader('Referer', $this->referer);
+    }
+
+    return $request;
+  }
+
 }

--- a/src/WebtoolsGeocoding.php
+++ b/src/WebtoolsGeocoding.php
@@ -22,7 +22,7 @@ class WebtoolsGeocoding extends AbstractHttpProvider {
   /**
    * @var string
    */
-  const ENDPOINT_URL = 'http://europa.eu/webtools/rest/geocoding/?f=json&text=%s&maxLocations=%d&outFields=*';
+  const ENDPOINT_URL = 'https://europa.eu/webtools/rest/geocoding/?f=json&text=%s&maxLocations=%d&outFields=*';
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
The Webtools Geocoding REST API requires the referer header to be set for certain projects that are behind a load balancer.

For the majority of projects this is not required, so the header should be optional.

For more information see:
- https://webgate.ec.europa.eu/CITnet/jira/browse/WEBTOOLS-9197
- https://webgate.ec.europa.eu/CITnet/jira/browse/ISAICP-5502